### PR TITLE
Fix multi-line clear bug in applyClears

### DIFF
--- a/app/modules/TetrisGame.tsx
+++ b/app/modules/TetrisGame.tsx
@@ -281,6 +281,8 @@ export const TetrisGame = () => {
     function applyClears() {
       for (const r of flashRows.slice().sort((a,b) => b - a)) {
         board.splice(r, 1);
+      }
+      for (let i = 0; i < flashRows.length; i++) {
         board.unshift(Array(COLS).fill(null));
       }
       flashRows = [];


### PR DESCRIPTION
board.unshift() was called inside the loop after each board.splice(), shifting all row indices up by 1 with every iteration. When clearing multiple rows (e.g. 18 and 19), the second splice would target the wrong index — leaving the upper full row on the board and deleting an unrelated row above it instead.

Fix: run all splice calls first (descending order so lower removals don't affect upper indices), then run all unshift calls afterward.

Single-line clears were unaffected; the bug only manifested on 2–4 simultaneous line clears.